### PR TITLE
Fix function `schedule` in sec 6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,7 +1261,7 @@ next task. The main schedule loop is:
             Hashtbl.remove ht x
       in
       resume br rdy_rd_fds;
-      resume br rdy_wr_fds;
+      resume bw rdy_wr_fds;
       schedule ()
     end
 ```

--- a/sources/echo_async.ml
+++ b/sources/echo_async.ml
@@ -96,7 +96,7 @@ module Aio : Aio = struct
             Hashtbl.remove ht x
       in
       resume br rdy_rd_fds;
-      resume br rdy_wr_fds;
+      resume bw rdy_wr_fds;
       schedule ()
     end
 

--- a/sources/solved/echo_async.ml
+++ b/sources/solved/echo_async.ml
@@ -98,7 +98,7 @@ module Aio : Aio = struct
             Hashtbl.remove ht x
       in
       resume br rdy_rd_fds;
-      resume br rdy_wr_fds;
+      resume bw rdy_wr_fds;
       schedule ()
     end
 


### PR DESCRIPTION
I used this tutorial to learn about algebraic effects.
It was very interesting.

I have one confirmation and a suggestion for modification.
- The `schedule` function described in section 6.2 resumes from a read blocked task using a file descriptor ready to be written.
- In this pull request, I changed it to resume from the task that blocked writing.

If I am wrong, I would be glad to know.
Please approve the pull request if you like.